### PR TITLE
Add stylometry framing and citations to abstract and core writeup

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -30,12 +30,14 @@
   \item We show that TAMV can be reliably inferred from dependency parses produced by the spaCy library for python. And, additionally, that Universal Dependencies (UD) representation is well-suited to robust large-scale extraction. \citep{Ramm2017AnnotatingGerman,Nivre2010DependencyParsing,Okhapkin2021ConstructingLibraries}
   \item We evaluate three prediction problems \textbf{separately}: register prediction, toxicity prediction, and VAD prediction, using task-appropriate datasets and metrics.
   \item We ground our hypothesis in Longman Grammar's documentation of register-conditioned TAMV variation, and derive validation test cases from its examples to evaluate extraction accuracy (Longman is not used as a prediction dataset). \citep{Biber20101999LongmanEnglish}
+  \item We position TAMV profiles as interpretable stylometric features: grammatical style signals that complement lexical stylometry for register and discourse modeling. \citep{Stamatatos2009SurveyMethods,Koppel2009ComputationalMethods}
 \end{itemize}
 \end{abstract}
 
 \section{Introduction}
 \begin{itemize}
   \item \textbf{Motivation:} Verb phrase choices encode temporal framing (tense/aspect), stance (mood/modality), and agency (voice); these grammatical choices vary systematically by register and interactional context. \citep{Biber20101999LongmanEnglish}
+  \item This framing aligns with computational stylometry, where quantitative linguistic features are used to model stylistic variation across domains such as authorship and register analysis. \citep{Holmes1998EvolutionStylometry,Stamatatos2009SurveyMethods}
   \item \textbf{Goal:} Build an interpretable TAMV extraction pipeline from dependency structure and test its usefulness in three downstream prediction settings \emph{evaluated independently}.
   \item \textbf{Claims:}
     \begin{itemize}
@@ -102,6 +104,7 @@
         \item \textbf{T}ense: PAST, \textbf{A}spect: SIMPLE, \textbf{M}ood: INDICATIVE, \textbf{V}oice: PASSIVE
       \end{itemize}
     \end{itemize}
+  \item Register analysis is closely related to stylometry: classic work emphasizes lexical markers (e.g., function-word distributions), while newer approaches benefit from linguistically structured grammatical features with clearer interpretability. \citep{Mosteller1964InferenceDisputedAuthorship,Argamon2007StylisticTextClassification,Biber2009RegisterGenreStyle}
 \end{itemize}
 
 \subsection{Dependency parsing and UD vs.\ SD framing}
@@ -132,6 +135,7 @@
 \subsection{Linguistic evidence for TAMV and register}
 \begin{itemize}
   \item Longman Grammar documents register-conditioned differences in verb phrase systems that motivate TAMV as a register-sensitive feature family. \citep{Biber20101999LongmanEnglish}
+  \item In stylometric terms, TAMV distributions operationalize grammatical style and complement lexical-only feature sets in text profiling. \citep{Stamatatos2009SurveyMethods,Koppel2009ComputationalMethods}
 \end{itemize}
 
 \subsection{Dependency-based TAMV/TMV extraction}
@@ -242,6 +246,7 @@
 \section{Discussion}
 \begin{itemize}
   \item Strengths: interpretable grammatical signal; portable extraction via spaCy/UD-style dependency structure. \citep{Nivre2010DependencyParsing,Okhapkin2021ConstructingLibraries}
+  \item Connection to stylometry: TAMV features provide a linguistically grounded alternative to surface-level lexical markers, supporting explainable style analysis across tasks. \citep{Mosteller1964InferenceDisputedAuthorship,Stamatatos2009SurveyMethods}
   \item What differs across tasks: why TAMV helps register, and what additional signals may be needed for toxicity and VAD (without conflating the evaluations).
   \item Role of Longman Grammar: theoretical grounding for TAMV--register connection and source of validation test cases, not a prediction dataset. \citep{Biber20101999LongmanEnglish}
 \end{itemize}

--- a/references.bib
+++ b/references.bib
@@ -203,3 +203,64 @@
     doi = {10.18653/v1/d18-1305},
     arxivId = {1810.13181}
 }
+
+@book{Mosteller1964InferenceDisputedAuthorship,
+    author = {Mosteller, Frederick and Wallace, David L.},
+    title = {Inference and Disputed Authorship: The Federalist},
+    year = {1964},
+    publisher = {Addison-Wesley},
+    address = {Reading, MA}
+}
+
+@article{Holmes1998EvolutionStylometry,
+    author = {Holmes, David I.},
+    title = {The Evolution of Stylometry in Humanities Scholarship},
+    journal = {Literary and Linguistic Computing},
+    year = {1998},
+    volume = {13},
+    number = {3},
+    pages = {111--117},
+    doi = {10.1093/llc/13.3.111}
+}
+
+@article{Stamatatos2009SurveyMethods,
+    author = {Stamatatos, Efstathios},
+    title = {A Survey of Modern Authorship Attribution Methods},
+    journal = {Journal of the American Society for Information Science and Technology},
+    year = {2009},
+    volume = {60},
+    number = {3},
+    pages = {538--556},
+    doi = {10.1002/asi.21001}
+}
+
+@article{Argamon2007StylisticTextClassification,
+    author = {Argamon, Shlomo and Whitelaw, Casey and Chase, Paul and Hota, Sobhan and Garg, Navendu and Levitan, Shlomo},
+    title = {Stylistic Text Classification Using Functional Lexical Features},
+    journal = {Journal of the American Society for Information Science and Technology},
+    year = {2007},
+    volume = {58},
+    number = {6},
+    pages = {802--822},
+    doi = {10.1002/asi.20553}
+}
+
+@article{Koppel2009ComputationalMethods,
+    author = {Koppel, Moshe and Schler, Jonathan and Argamon, Shlomo},
+    title = {Computational Methods in Authorship Attribution},
+    journal = {Journal of the American Society for Information Science and Technology},
+    year = {2009},
+    volume = {60},
+    number = {1},
+    pages = {9--26},
+    doi = {10.1002/asi.20961}
+}
+
+@book{Biber2009RegisterGenreStyle,
+    author = {Biber, Douglas and Conrad, Susan},
+    title = {Register, Genre, and Style},
+    year = {2009},
+    publisher = {Cambridge University Press},
+    address = {Cambridge},
+    doi = {10.1017/CBO9780511814354}
+}


### PR DESCRIPTION
## Summary
- add explicit stylometry framing to the abstract
- add stylometry context sentence in Introduction
- add register-to-stylometry bridge in Background (§2.1)
- add TAMV-as-stylometric bullet in Related Work (§3.1)
- add stylometry contribution bullet in Discussion (§8)
- add supporting stylometry references in  (Mosteller & Wallace, Holmes, Stamatatos, Argamon, Koppel, Biber & Conrad)

## Issue
Closes #18