### PR TITLE
Add reproducible TMV alignment audit for intrinsic evaluation

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -82,6 +82,9 @@ python -m tests.validate_tamv --no-show
 # Phrase-level validation (32 test cases with 43 verb phrases)
 python -m tests.validate_phrases --no-show
 
+# TMV compatibility check on the GitHub-published Mate sample
+python scripts/tmv_alignment_test.py
+
 # Show interactive confusion matrix plots
 python -m tests.validate_tamv
 python -m tests.validate_phrases

--- a/code/docs/intrinsic_data_audit.md
+++ b/code/docs/intrinsic_data_audit.md
@@ -1,0 +1,104 @@
+# Intrinsic Data Audit
+
+This note records what intrinsic data is actually available in the repository, what came from the TMV-annotator project, and why the current external comparison is useful but limited.
+
+## Available intrinsic sources
+
+### 1. Curated TAMV gold suites
+
+- `code/data/synthetic_expected.tsv`: `83` labeled verb instances
+  - `40` rows labeled `User test data`
+  - `25` rows labeled `Brown corpus`
+  - `18` rows labeled `Longman Grammar (Ch. 5-6)`
+- `code/data/phrase_test_expected.json`: `32` phrase-level cases
+
+These files are the current direct TAMV gold resources in the repo.
+
+### 2. TMV-annotator GitHub sample
+
+The upstream TMV-annotator GitHub repository publishes a small English Mate-parsed sample and TMV output:
+
+- `example-outputs/en.parsed`
+- `tmv-annotator-tool/output/en.parsed.verbs`
+
+The local repo vendors that sample as:
+
+- `code/data/europarl_sentences.txt`
+- `code/data/europarl_expected.tsv`
+- `code/data/europarl_tamv.tsv`
+
+This sample contains:
+
+- `25` sentences
+- `35` TMV rows total
+- `27` finite rows after local TMV->TAMV conversion
+
+Important: this is a comparison against TMV-annotator output, not a direct human-gold TAMV corpus.
+
+## Why the old “full Europarl” path is not reproducible
+
+The upstream GitHub repo points to a separate Dropbox archive for a larger Europarl corpus. That archive is no longer accessible from the original URL, and the local repo never versioned the reference bundle itself.
+
+The repo also ignores `tmv_annotator_reference/` at the root, so any local copy of the upstream reference materials would not have been committed by default.
+
+## Is the GitHub sample statistically strong enough?
+
+No, not as a headline intrinsic benchmark.
+
+Current TMV alignment figures on the GitHub sample:
+
+- Detection: `27/35 = 77.1%`
+  - 95% Wilson CI: `61.0%` to `87.9%`
+- Full TAMV match among matched finite rows: `26/27 = 96.3%`
+  - 95% Wilson CI: `81.7%` to `99.3%`
+
+Why this is not strong enough on its own:
+
+- Only `27` finite comparable rows are available after conversion.
+- The sample is small and not demonstrably representative.
+- The comparison target is TMV-annotator system output, not independent human TAMV gold.
+
+So the GitHub sample is useful as an external compatibility check, but not sufficient as the sole intrinsic claim.
+
+## Other realistic data sources
+
+### Universal Dependencies English treebanks
+
+Official index: <https://universaldependencies.org/en/index.html>
+
+Pros:
+
+- Openly accessible
+- Broad genre coverage
+- Gold syntax and morphology
+
+Cons:
+
+- Not already labeled with this project’s TAMV scheme
+- Requires manual TAMV annotation or a carefully reviewed conversion layer
+
+### PropBank / OntoNotes-style inflection fields
+
+The Ramm et al. paper notes that PropBank includes inflectional information for tense, aspect, and voice, but not all moods; subjunctive constructions are especially under-covered. These resources are also distributed through LDC rather than openly mirrored on GitHub.
+
+Pros:
+
+- Larger and more systematic than the current GitHub TMV sample
+- Useful for partial validation of tense/aspect/voice
+
+Cons:
+
+- Not a full TAMV benchmark in the current label scheme
+- Access is license-gated
+- Mood coverage is incomplete
+
+### TimeBank / TimeML-style corpora
+
+These are useful for tense/aspect and event-time evaluation, but they are not direct TAMV resources and are weaker for voice and mood.
+
+## Recommended interpretation
+
+- Keep the curated single-verb and phrase suites as direct TAMV stress tests.
+- Keep the GitHub TMV sample as a separate external compatibility check.
+- Do not present the GitHub sample as if it were a large hand-annotated gold corpus.
+- If a stronger benchmark is needed, the best next open path is to annotate a new TAMV subset from UD English treebanks.

--- a/code/docs/intrinsic_reproducibility.md
+++ b/code/docs/intrinsic_reproducibility.md
@@ -1,0 +1,61 @@
+# Intrinsic TAMV Reproducibility
+
+This note records the commands and artifact locations for the intrinsic TAMV validation track.
+
+The intrinsic package has two different evaluation modes:
+
+- Curated TAMV gold suites: single-verb and phrase-level regression/stress tests.
+- TMV alignment sample: a small GitHub-published Mate/TMV comparison sample from Ramm et al.'s TMV-annotator repository.
+
+## Commands
+
+Run the single-verb validation:
+
+```bash
+cd code
+python -m tests.validate_tamv --no-show
+```
+
+Run the phrase-level validation:
+
+```bash
+cd code
+python -m tests.validate_phrases --no-show
+```
+
+Run the GitHub-sample TMV alignment check:
+
+```bash
+python code/scripts/tmv_alignment_test.py
+```
+
+## Expected artifacts
+
+The validation scripts write their outputs under `code/output/`:
+
+- `validation_report.txt`
+- `confusion_tense.png`
+- `confusion_aspect.png`
+- `confusion_mood.png`
+- `confusion_voice.png`
+- `confusion_matrices_combined.png`
+- `phrase_validation_report.txt`
+- `phrase_confusion_tense.png`
+- `phrase_confusion_aspect.png`
+- `phrase_confusion_mood.png`
+- `phrase_confusion_voice.png`
+- `phrase_confusion_matrices_combined.png`
+- `tmv_alignment_report.txt`
+- `tmv_alignment_mismatches.tsv`
+
+## Interpretation notes
+
+- The single-verb report is the primary intrinsic evaluation summary.
+- The phrase-level report is the stricter structural check for multi-verb and span-matching cases.
+- The TMV alignment report is an external compatibility check against the GitHub-published TMV-annotator sample. It is not a human-gold TAMV benchmark.
+- The main known failure modes remain subjunctive, conditional, and a few non-finite or negation-heavy constructions.
+- The GitHub TMV sample is small (`25` sentences, `35` TMV rows, `27` finite comparable rows) and should be treated as a sanity check, not as a statistically strong standalone benchmark.
+
+## Paper-facing file set
+
+When the intrinsic outputs are packaged for the manuscript, the bundle should include the reports above plus the corresponding confusion-matrix figures in a stable directory layout.

--- a/code/output/tmv_alignment_mismatches.tsv
+++ b/code/output/tmv_alignment_mismatches.tsv
@@ -1,0 +1,2 @@
+sentence_index	sentence	verb	gold_label	predicted_label	predicted_verb_text	predicted_lemma	auxiliary_chain
+2	SAN FRANCISCO - It has never been easy to have a rational conversation about the value of gold .	been	present-perfect-indicative-passive	present-perfect-indicative-active	been	be	has

--- a/code/output/tmv_alignment_report.txt
+++ b/code/output/tmv_alignment_report.txt
@@ -1,22 +1,37 @@
 TMV ALIGNMENT REPORT
 ======================================================================
 
-Total TMV-annotator verbs: 35
+Reference sample: GitHub-published English Mate/TMV sample from the TMV-annotator repository
+
+Sentence count: 25
+Total TMV-annotator rows: 35
+Comparable finite rows after TMV->TAMV conversion: 27
 Matched verbs: 27
 Detection rate: 77.1%
+  95% Wilson CI: [61.0%, 87.9%]
 
-Alignment by dimension:
+Alignment by dimension on matched verbs:
   Tense:  100.0%
   Aspect: 100.0%
   Mood:   100.0%
   Voice:  96.3%
   Full:   96.3%
+  Full-match 95% Wilson CI: [81.7%, 99.3%]
+
+Comparison policy:
+- Non-finite TMV rows are excluded from the TAMV alignment denominator because the local conversion only maps finite TMV rows.
+- Local MODAL labels are collapsed back to TMV-compatible indicative/subjunctive values for this comparison only.
 
 ALL MISMATCHES:
 ----------------------------------------------------------------------
 
-Sentence 2: SAN FRANCISCO - It has never been easy to have a rational co...
+Sentence 2: SAN FRANCISCO - It has never been easy to have a rational conversation
   Verb: been
-  TMV-annotator: presPerf/indicative/passive/prog=no
   TMV (mapped):  present-perfect-indicative-passive
   Our extractor: present-perfect-indicative-active
+
+
+UNMATCHED CONVERTED ROWS:
+----------------------------------------------------------------------
+
+None

--- a/code/scripts/package_intrinsic_outputs.py
+++ b/code/scripts/package_intrinsic_outputs.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Package intrinsic TAMV validation artifacts for paper use.
+
+This script copies the existing intrinsic validation outputs into a dedicated
+paper-ready directory and writes a compact summary table extracted from the
+checked-in validation reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import shutil
+from pathlib import Path
+
+
+SINGLE_PATTERNS = {
+    "overall_accuracy": r"Overall accuracy:\s+([0-9.]+%)",
+    "verb_detection": r"Verb detection rate:\s+([0-9.]+%)",
+    "tense_accuracy": r"Tense:\s+([0-9.]+%)",
+    "aspect_accuracy": r"Aspect:\s+([0-9.]+%)",
+    "mood_accuracy": r"Mood:\s+([0-9.]+%)",
+    "voice_accuracy": r"Voice:\s+([0-9.]+%)",
+}
+
+TMV_PATTERNS = {
+    "sentence_count": r"Sentence count:\s+([0-9]+)",
+    "tmv_rows": r"Total TMV-annotator rows:\s+([0-9]+)",
+    "comparable_rows": r"Comparable finite rows after TMV->TAMV conversion:\s+([0-9]+)",
+    "matched_verbs": r"Matched verbs:\s+([0-9]+)",
+    "detection_rate": r"Detection rate:\s+([0-9.]+%)",
+    "full_alignment": r"  Full:\s+([0-9.]+%)",
+}
+
+PHRASE_PATTERNS = {
+    "labels_correct": r"Labels fully correct:\s+([0-9]+ \([0-9.]+%\))",
+    "phrases_detected": r"Phrases detected:\s+([0-9]+ \([0-9.]+%\))",
+    "tense_accuracy": r"Tense:\s+([0-9.]+%)",
+    "aspect_accuracy": r"Aspect:\s+([0-9.]+%)",
+    "mood_accuracy": r"Mood:\s+([0-9.]+%)",
+    "voice_accuracy": r"Voice:\s+([0-9.]+%)",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    code_dir = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description="Package intrinsic validation artifacts.")
+    parser.add_argument("--input-dir", type=Path, default=code_dir / "output")
+    parser.add_argument("--output-dir", type=Path, default=code_dir / "output" / "intrinsic_paper")
+    return parser.parse_args()
+
+
+def extract_metrics(text: str, patterns: dict[str, str], prefix: str) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    for metric, pattern in patterns.items():
+        match = re.search(pattern, text, flags=re.MULTILINE)
+        if match:
+            rows.append((f"{prefix}_{metric}", match.group(1)))
+    return rows
+
+
+def copy_artifacts(input_dir: Path, output_dir: Path) -> list[Path]:
+    files = [
+        "validation_report.txt",
+        "confusion_tense.png",
+        "confusion_aspect.png",
+        "confusion_mood.png",
+        "confusion_voice.png",
+        "confusion_matrices_combined.png",
+        "phrase_validation_report.txt",
+        "phrase_confusion_tense.png",
+        "phrase_confusion_aspect.png",
+        "phrase_confusion_mood.png",
+        "phrase_confusion_voice.png",
+        "phrase_confusion_matrices_combined.png",
+    ]
+    optional_files = [
+        "tmv_alignment_report.txt",
+        "tmv_alignment_mismatches.tsv",
+    ]
+
+    copied: list[Path] = []
+    for name in files:
+        src = input_dir / name
+        if not src.exists():
+            raise FileNotFoundError(f"Missing required artifact: {src}")
+        dst = output_dir / name
+        shutil.copy2(src, dst)
+        copied.append(dst)
+
+    for name in optional_files:
+        src = input_dir / name
+        if src.exists():
+            dst = output_dir / name
+            shutil.copy2(src, dst)
+            copied.append(dst)
+
+    return copied
+
+
+def write_summary(output_dir: Path, single_report: Path, phrase_report: Path, tmv_report: Path | None) -> Path:
+    single_text = single_report.read_text(encoding="utf-8")
+    phrase_text = phrase_report.read_text(encoding="utf-8")
+    rows = [
+        ("task", "metric", "value"),
+        ("single", "source_report", single_report.name),
+        ("phrase", "source_report", phrase_report.name),
+    ]
+    if tmv_report is not None:
+        rows.append(("tmv_alignment", "source_report", tmv_report.name))
+    rows.extend(("single", metric, value) for metric, value in extract_metrics(single_text, SINGLE_PATTERNS, "single"))
+    rows.extend(("phrase", metric, value) for metric, value in extract_metrics(phrase_text, PHRASE_PATTERNS, "phrase"))
+    if tmv_report is not None:
+        tmv_text = tmv_report.read_text(encoding="utf-8")
+        rows.extend(("tmv_alignment", metric, value) for metric, value in extract_metrics(tmv_text, TMV_PATTERNS, "tmv"))
+
+    summary_path = output_dir / "intrinsic_summary.tsv"
+    with summary_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerows(rows)
+    return summary_path
+
+
+def write_markdown(output_dir: Path, summary_path: Path) -> Path:
+    md_path = output_dir / "intrinsic_summary.md"
+    lines = [
+        "# Intrinsic Validation Summary",
+        "",
+        "Packaged from the checked-in intrinsic validation reports.",
+        "",
+        f"- Summary table: `{summary_path.name}`",
+        "- Single-verb figures and report: `validation_report.txt` and `confusion_*.png`",
+        "- Phrase-level figures and report: `phrase_validation_report.txt` and `phrase_confusion_*.png`",
+        "- TMV compatibility sample: `tmv_alignment_report.txt` and `tmv_alignment_mismatches.tsv` when present",
+        "",
+    ]
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return md_path
+
+
+def write_category_table(output_dir: Path, single_report: Path) -> Path:
+    text = single_report.read_text(encoding="utf-8")
+    rows = []
+    in_section = False
+    for line in text.splitlines():
+        if line.startswith("ACCURACY BY CATEGORY"):
+            in_section = True
+            continue
+        if in_section and line.startswith("TENSE CONFUSION MATRIX"):
+            break
+        if in_section:
+            match = re.match(r"\s*([A-Za-z0-9_:-]+)\s+(\d+/\s*\d+\s+\([0-9.]+%\))", line)
+            if match:
+                rows.append((match.group(1), match.group(2)))
+
+    path = output_dir / "single_category_accuracy.tsv"
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(["category", "accuracy"])
+        writer.writerows(rows)
+    return path
+
+
+def write_failure_table(output_dir: Path, single_report: Path, phrase_report: Path) -> Path:
+    def extract_failures(text: str, report: str) -> list[tuple[str, str, str, str, str]]:
+        rows: list[tuple[str, str, str, str, str]] = []
+        sentence = ""
+        verb = ""
+        category = ""
+        expected = ""
+        got = ""
+        in_section = False
+        for line in text.splitlines():
+            if line.startswith("FAILED TEST CASES"):
+                in_section = True
+                continue
+            if not in_section:
+                continue
+            if line.startswith("  Sentence: "):
+                sentence = line.split("Sentence: ", 1)[1].strip().strip('"')
+                verb = ""
+                category = ""
+                expected = ""
+                got = ""
+            elif line.startswith("  ID ") and ":" in line:
+                sentence = line.split(":", 1)[1].strip().strip('"')
+                verb = ""
+                category = ""
+                expected = ""
+                got = ""
+            elif line.strip().startswith("- '") and "':" in line:
+                verb = line.strip().split("':", 1)[0].lstrip("- *").strip("'")
+            elif line.startswith("  Verb: "):
+                verb = line.split("Verb: ", 1)[1].strip()
+            elif line.startswith("  Category: "):
+                category = line.split("Category: ", 1)[1].strip()
+            elif line.startswith("  Expected: "):
+                expected = line.split("Expected: ", 1)[1].strip()
+            elif line.startswith("  Got: "):
+                got = line.split("Got: ", 1)[1].strip()
+            elif line.strip().startswith("- ") or line.strip().startswith("* "):
+                rows.append((report, sentence, verb, category, f"{line.strip()} | expected={expected} | got={got}"))
+        return rows
+
+    rows = extract_failures(single_report.read_text(encoding="utf-8"), "single")
+    rows.extend(extract_failures(phrase_report.read_text(encoding="utf-8"), "phrase"))
+
+    path = output_dir / "failure_cases.tsv"
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(["report", "sentence", "verb", "category", "note"])
+        writer.writerows(rows)
+    return path
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    copied = copy_artifacts(args.input_dir, args.output_dir)
+    summary_path = write_summary(
+        args.output_dir,
+        args.input_dir / "validation_report.txt",
+        args.input_dir / "phrase_validation_report.txt",
+        args.input_dir / "tmv_alignment_report.txt" if (args.input_dir / "tmv_alignment_report.txt").exists() else None,
+    )
+    category_path = write_category_table(args.output_dir, args.input_dir / "validation_report.txt")
+    failure_path = write_failure_table(
+        args.output_dir,
+        args.input_dir / "validation_report.txt",
+        args.input_dir / "phrase_validation_report.txt",
+    )
+    md_path = write_markdown(args.output_dir, summary_path)
+    manifest = {
+        "copied_artifacts": [str(path.name) for path in copied],
+        "summary_table": summary_path.name,
+        "category_table": category_path.name,
+        "failure_table": failure_path.name,
+    }
+    (args.output_dir / "bundle_manifest.json").write_text(
+        json.dumps(manifest, indent=2),
+        encoding="utf-8",
+    )
+
+    print(f"Packaged {len(copied)} artifacts into {args.output_dir}")
+    print(f"Summary table: {summary_path}")
+    print(f"Markdown note: {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/scripts/tmv_alignment_test.py
+++ b/code/scripts/tmv_alignment_test.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Compare the local spaCy extractor against the GitHub-published TMV sample.
+
+This script evaluates compatibility with the English TMV-annotator sample that
+is published directly in the upstream GitHub repository:
+
+- example-outputs/en.parsed
+- tmv-annotator-tool/output/en.parsed.verbs
+
+The local repo vendors sentence text and TMV rows derived from that sample in:
+
+- code/data/europarl_sentences.txt
+- code/data/europarl_expected.tsv
+- code/data/europarl_tamv.tsv
+
+The comparison is intentionally separate from the curated intrinsic gold suite:
+it measures agreement with TMV-annotator output on a small Mate-parsed sample,
+not direct agreement with human TAMV annotations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CODE_DIR = Path(__file__).resolve().parents[1]
+if str(CODE_DIR) not in sys.path:
+    sys.path.insert(0, str(CODE_DIR))
+
+from src.tamv_extractor import TAMVExtractor, TAMVLabel  # noqa: E402
+
+
+@dataclass
+class TmvRow:
+    sentence_index: int
+    verb: str
+    is_finite: bool
+    tmv_tense: str
+    tmv_mood: str
+    tmv_voice: str
+    progressive: str
+
+
+@dataclass
+class ConvertedRow:
+    sentence_index: int
+    verb: str
+    tense: str
+    aspect: str
+    mood: str
+    voice: str
+
+    def label(self) -> str:
+        return "-".join(
+            [
+                self.tense.lower(),
+                self.aspect.lower().replace("_", "-"),
+                self.mood.lower(),
+                self.voice.lower(),
+            ]
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run TMV alignment on the GitHub-published Mate sample.")
+    parser.add_argument("--sentences", type=Path, default=CODE_DIR / "data" / "europarl_sentences.txt")
+    parser.add_argument("--tmv-rows", type=Path, default=CODE_DIR / "data" / "europarl_expected.tsv")
+    parser.add_argument("--converted-gold", type=Path, default=CODE_DIR / "data" / "europarl_tamv.tsv")
+    parser.add_argument("--report", type=Path, default=CODE_DIR / "output" / "tmv_alignment_report.txt")
+    parser.add_argument("--mismatches", type=Path, default=CODE_DIR / "output" / "tmv_alignment_mismatches.tsv")
+    parser.add_argument("--model", default="en_core_web_sm")
+    return parser.parse_args()
+
+
+def normalize_token(text: str) -> str:
+    return re.sub(r"[^a-z]+", "", text.lower())
+
+
+def load_sentences(path: Path) -> dict[int, str]:
+    with path.open("r", encoding="utf-8") as handle:
+        return {
+            index: line.strip()
+            for index, line in enumerate(handle, start=1)
+            if line.strip()
+        }
+
+
+def load_tmv_rows(path: Path) -> list[TmvRow]:
+    rows: list[TmvRow] = []
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        for raw in reader:
+            if not raw:
+                continue
+            rows.append(
+                TmvRow(
+                    sentence_index=int(raw[0]),
+                    verb=raw[4],
+                    is_finite=raw[3] == "yes" and raw[5] != "-",
+                    tmv_tense=raw[5],
+                    tmv_mood=raw[6],
+                    tmv_voice=raw[7],
+                    progressive=raw[8],
+                )
+            )
+    return rows
+
+
+def load_converted_rows(path: Path) -> list[ConvertedRow]:
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        return [
+            ConvertedRow(
+                sentence_index=int(row["index"]),
+                verb=row["verb"],
+                tense=row["tense"],
+                aspect=row["aspect"],
+                mood=row["mood"],
+                voice=row["voice"],
+            )
+            for row in reader
+        ]
+
+
+def tmv_compatible_label(label: TAMVLabel) -> str:
+    mood = label.mood.value
+    if mood == "modal":
+        auxiliaries = {aux.lower() for aux in label.auxiliary_chain}
+        if auxiliaries & {"would", "could", "should", "might"}:
+            mood = "subjunctive"
+        else:
+            mood = "indicative"
+    return "-".join([label.tense.value, label.aspect.value, mood, label.voice.value])
+
+
+def match_label(verb: str, labels: list[TAMVLabel]) -> TAMVLabel | None:
+    gold = normalize_token(verb)
+    for label in labels:
+        candidates = [
+            normalize_token(label.verb_text),
+            normalize_token(label.verb_lemma),
+            *[normalize_token(aux) for aux in label.auxiliary_chain],
+        ]
+        if gold in candidates:
+            return label
+        if any(gold and candidate and (gold in candidate or candidate in gold) for candidate in candidates):
+            return label
+    return None
+
+
+def wilson_interval(successes: int, total: int, z: float = 1.96) -> tuple[float, float]:
+    if total == 0:
+        return 0.0, 0.0
+    phat = successes / total
+    denom = 1.0 + (z * z / total)
+    center = (phat + (z * z) / (2 * total)) / denom
+    margin = (z * math.sqrt((phat * (1 - phat) + (z * z) / (4 * total)) / total)) / denom
+    return center - margin, center + margin
+
+
+def main() -> None:
+    args = parse_args()
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.mismatches.parent.mkdir(parents=True, exist_ok=True)
+
+    sentences = load_sentences(args.sentences)
+    tmv_rows = load_tmv_rows(args.tmv_rows)
+    converted_rows = load_converted_rows(args.converted_gold)
+    extractor = TAMVExtractor(model=args.model)
+
+    sentence_labels: dict[int, list[TAMVLabel]] = {
+        index: extractor.extract_from_text(sentence)
+        for index, sentence in sentences.items()
+    }
+
+    matched_rows: list[tuple[ConvertedRow, TAMVLabel]] = []
+    mismatches: list[dict[str, str]] = []
+    missing_rows: list[ConvertedRow] = []
+    dimension_correct = {"tense": 0, "aspect": 0, "mood": 0, "voice": 0, "full": 0}
+
+    for row in converted_rows:
+        labels = sentence_labels.get(row.sentence_index, [])
+        label = match_label(row.verb, labels)
+        if label is None:
+            missing_rows.append(row)
+            continue
+
+        matched_rows.append((row, label))
+        compatible = tmv_compatible_label(label)
+        gold = row.label()
+        predicted_parts = compatible.split("-")
+        gold_parts = gold.split("-")
+        tense_pred, aspect_pred = predicted_parts[0], "-".join(predicted_parts[1:-2])
+        mood_pred, voice_pred = predicted_parts[-2], predicted_parts[-1]
+        tense_gold, aspect_gold = gold_parts[0], "-".join(gold_parts[1:-2])
+        mood_gold, voice_gold = gold_parts[-2], gold_parts[-1]
+
+        if tense_pred == tense_gold:
+            dimension_correct["tense"] += 1
+        if aspect_pred == aspect_gold:
+            dimension_correct["aspect"] += 1
+        if mood_pred == mood_gold:
+            dimension_correct["mood"] += 1
+        if voice_pred == voice_gold:
+            dimension_correct["voice"] += 1
+        if compatible == gold:
+            dimension_correct["full"] += 1
+        else:
+            mismatches.append(
+                {
+                    "sentence_index": str(row.sentence_index),
+                    "sentence": sentences[row.sentence_index],
+                    "verb": row.verb,
+                    "gold_label": gold,
+                    "predicted_label": compatible,
+                    "predicted_verb_text": label.verb_text,
+                    "predicted_lemma": label.verb_lemma,
+                    "auxiliary_chain": " ".join(label.auxiliary_chain),
+                }
+            )
+
+    detection_lo, detection_hi = wilson_interval(len(matched_rows), len(tmv_rows))
+    full_lo, full_hi = wilson_interval(dimension_correct["full"], len(matched_rows))
+
+    report_lines = [
+        "TMV ALIGNMENT REPORT",
+        "=" * 70,
+        "",
+        "Reference sample: GitHub-published English Mate/TMV sample from the TMV-annotator repository",
+        "",
+        f"Sentence count: {len(sentences)}",
+        f"Total TMV-annotator rows: {len(tmv_rows)}",
+        f"Comparable finite rows after TMV->TAMV conversion: {len(converted_rows)}",
+        f"Matched verbs: {len(matched_rows)}",
+        f"Detection rate: {len(matched_rows) / len(tmv_rows):.1%}",
+        f"  95% Wilson CI: [{detection_lo:.1%}, {detection_hi:.1%}]",
+        "",
+        "Alignment by dimension on matched verbs:",
+        f"  Tense:  {dimension_correct['tense'] / len(matched_rows):.1%}",
+        f"  Aspect: {dimension_correct['aspect'] / len(matched_rows):.1%}",
+        f"  Mood:   {dimension_correct['mood'] / len(matched_rows):.1%}",
+        f"  Voice:  {dimension_correct['voice'] / len(matched_rows):.1%}",
+        f"  Full:   {dimension_correct['full'] / len(matched_rows):.1%}",
+        f"  Full-match 95% Wilson CI: [{full_lo:.1%}, {full_hi:.1%}]",
+        "",
+        "Comparison policy:",
+        "- Non-finite TMV rows are excluded from the TAMV alignment denominator because the local conversion only maps finite TMV rows.",
+        "- Local MODAL labels are collapsed back to TMV-compatible indicative/subjunctive values for this comparison only.",
+        "",
+        "ALL MISMATCHES:",
+        "-" * 70,
+        "",
+    ]
+
+    if mismatches:
+        for row in mismatches:
+            report_lines.extend(
+                [
+                    f"Sentence {row['sentence_index']}: {row['sentence'][:70]}",
+                    f"  Verb: {row['verb']}",
+                    f"  TMV (mapped):  {row['gold_label']}",
+                    f"  Our extractor: {row['predicted_label']}",
+                    "",
+                ]
+            )
+    else:
+        report_lines.append("None")
+
+    report_lines.extend(
+        [
+            "",
+            "UNMATCHED CONVERTED ROWS:",
+            "-" * 70,
+            "",
+        ]
+    )
+    if missing_rows:
+        for row in missing_rows:
+            report_lines.append(f"Sentence {row.sentence_index}: {row.verb} ({row.label()})")
+    else:
+        report_lines.append("None")
+
+    args.report.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+
+    with args.mismatches.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "sentence_index",
+                "sentence",
+                "verb",
+                "gold_label",
+                "predicted_label",
+                "predicted_verb_text",
+                "predicted_lemma",
+                "auxiliary_chain",
+            ],
+            delimiter="\t",
+        )
+        writer.writeheader()
+        writer.writerows(mismatches)
+
+    print(f"Wrote report to {args.report}")
+    print(f"Wrote mismatch table to {args.mismatches}")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.tex
+++ b/main.tex
@@ -204,7 +204,7 @@
   \item We do not prioritize deep neural models in the core register experiment because the currently labeled document-level register set is relatively small; this limits reliable estimation and can inflate variance without careful regularization and substantially larger labeled corpora.
   \item \textbf{Baselines:}
     \begin{itemize}
-      \item \emph{Intrinsic:} Comparison against TMV-annotator output on Europarl sentences parsed by both Mate (SD) and spaCy (UD).
+      \item \emph{Intrinsic:} Curated TAMV gold suites plus a separate compatibility comparison against the GitHub-published TMV-annotator Mate sample.
       \item \emph{Register:} Majority-class baseline and bag-of-words logistic regression.
       \item \emph{Toxicity:} Majority-class baseline and lexicon-based approaches.
       \item \emph{VAD:} Mean-value baseline and lexicon-only regression.
@@ -217,7 +217,7 @@ We separate intrinsic and extrinsic evaluation by design: Exp 0 measures TAMV ex
 
 \subsection{Intrinsic evaluation: TAMV extraction reliability}
 \begin{itemize}
-  \item Evaluate extracted TAMV against gold annotations derived from Longman Grammar examples: per-dimension accuracy/F1 and joint-label accuracy; error taxonomy. \citep{Biber20101999LongmanEnglish,Ramm2017AnnotatingGerman}
+  \item We evaluate extracted TAMV against curated TAMV gold suites derived from Brown examples, user-authored stress tests, and Longman-based phrase examples. Separately, we compare the extractor against the GitHub-published English Mate/TMV sample from TMV-annotator (25 sentences; 35 TMV rows, 27 finite comparable rows). This external sample is a compatibility check against TMV-annotator output, not a standalone human-gold benchmark. \citep{Biber20101999LongmanEnglish,Ramm2017AnnotatingGerman}
 \end{itemize}
 
 \subsection{Register prediction (Brown)}
@@ -241,7 +241,7 @@ We separate intrinsic and extrinsic evaluation by design: Exp 0 measures TAMV ex
 
 \section{Results}
 \begin{itemize}
-  \item \textbf{TAMV reliability:} performance on Longman-derived test cases and major error sources. \citep{Biber20101999LongmanEnglish,Ramm2017AnnotatingGerman}
+  \item \textbf{TAMV reliability:} the curated TAMV gold suites remain the primary intrinsic benchmark, while the GitHub-published TMV sample provides a small external compatibility check. On that TMV sample, the current alignment report covers 25 sentences, 35 TMV rows, and 27 finite comparable rows, with 96.3\% full TAMV agreement on matched rows. Because this sample is small and compares against TMV-annotator output rather than human gold, it should not be treated as the sole intrinsic claim. \citep{Biber20101999LongmanEnglish,Ramm2017AnnotatingGerman}
   \item \textbf{Register:} Brown prediction performance + interpretable TAMV feature importance; sanity-check alignment with Longman. \citep{19684/682R15.00.,Biber20101999LongmanEnglish} For register prediction, we report comparative performance for majority, BoW, and TAMV-based models, then analyze per-genre confusion patterns to identify where TAMV contributes most strongly. We also inspect top weighted TAMV features per genre to connect predictive behavior back to interpretable grammatical variation.
   \item \textbf{Toxicity:} report classifier results on CGA with baseline comparisons and failure analysis by conversation stage. \citep{Zhang2018ConversationsFailure}
   \item \textbf{VAD:} report per-dimension (V/A/D) performance with regression/classification metrics and lexicon-baseline gaps. \citep{Buechel2017EmoBank:Analysis,Mohammad2018ObtainingWords}


### PR DESCRIPTION
## Summary
- add a committed `tmv_alignment_test.py` runner for the GitHub-published English Mate/TMV sample from TMV-annotator
- package the TMV alignment report alongside the existing intrinsic artifacts
- document the intrinsic data situation, including why the TMV GitHub sample is useful but too small to serve as the sole intrinsic benchmark
- update README/manuscript wording so the TMV sample is described as a compatibility check rather than a full Europarl gold corpus

## Verification
- `python -m py_compile code/scripts/tmv_alignment_test.py code/scripts/package_intrinsic_outputs.py`
- `python code/scripts/tmv_alignment_test.py`
- `python code/scripts/package_intrinsic_outputs.py`

## Notes
- The GitHub-published sample covers 25 sentences / 35 TMV rows / 27 finite comparable rows.
- The regenerated alignment report remains at 96.3% full TAMV agreement on matched rows, with one remaining copular/passive mismatch.